### PR TITLE
A few bugfixes and new features

### DIFF
--- a/Contents/Code/fanza_updater.py
+++ b/Contents/Code/fanza_updater.py
@@ -95,14 +95,17 @@ def update(metadata):  # noqa: C901
 
     # check posters from sample images, should have the highest resolution
     if image_helper.can_analyze_images:
-        image_urls = item.sampleImageURL.sample_s.image
-        for image_url in image_urls[:min(len(image_urls), 3)]:  # only check the first 3 items
-            image_url = image_url.replace("-", "jp-")
-            Log.Info("Checking sample image: {}".format(image_url))
-            if image_helper.are_similar(image_url, item.imageURL.small):
-                Log.Info("Found a better poster from sample images: {}".format(image_url))
-                metadata.posters[image_url] = Proxy.Media(HTTP.Request(image_url))
-                break
+        try:
+            image_urls = item.sampleImageURL.sample_s.image
+            for image_url in image_urls[:min(len(image_urls), 3)]:  # only check the first 3 items
+                image_url = image_url.replace("-", "jp-")
+                Log.Info("Checking sample image: {}".format(image_url))
+                if image_helper.are_similar(image_url, item.imageURL.small):
+                    Log.Info("Found a better poster from sample images: {}".format(image_url))
+                    metadata.posters[image_url] = Proxy.Media(HTTP.Request(image_url))
+                    break
+        except AttributeError:
+            pass
     if len(metadata.posters) == 0:
         Log.Info("Within sample images it does not seem to have a poster")
 

--- a/Contents/Code/fanza_updater.py
+++ b/Contents/Code/fanza_updater.py
@@ -48,7 +48,7 @@ def update(metadata):  # noqa: C901
     metadata.title = "{}{}".format(item.product_id.upper(), part_text)
     metadata.original_title = item.title
     metadata.year = date.year
-    metadata.rating = float(item.review.average) if 'review' in item else 0.0
+    metadata.rating = 2.0 * float(item.review.average) if 'review' in item else 0.0
     metadata.content_rating_age = 18
     metadata.content_rating = "Adult"
     metadata.originally_available_at = date

--- a/Contents/Code/fanza_updater.py
+++ b/Contents/Code/fanza_updater.py
@@ -59,8 +59,16 @@ def update(metadata):  # noqa: C901
     # TODO: More details needed
     # metadata.countries = {"Japan"}
     # metadata.writers = {}
-    # metadata.directors = {}
     # metadata.producers = {}
+
+    # setting up directors
+    try:
+        metadata.directors.clear()
+        for director in item.iteminfo.director:
+            Log.Info(u"Adding director: {}".format(director.name))
+            metadata.directors.new().name = director.name
+    except AttributeError:
+        pass
 
     # setting up genres
     metadata.genres.clear()

--- a/Contents/Code/image_helper.py
+++ b/Contents/Code/image_helper.py
@@ -77,6 +77,7 @@ def get_image_info(data):  # noqa: C901
         jpeg.read(2)
         b = jpeg.read(1)
         try:
+            h, w = -1, -1
             while b and ord(b) != 0xDA:
                 while ord(b) != 0xFF:
                     b = jpeg.read(1)

--- a/Contents/Code/jav_agent.py
+++ b/Contents/Code/jav_agent.py
@@ -81,12 +81,15 @@ class JavMovieAgent(Agent.Movies):
         Log.Debug("part_number: {}".format(part_number))
 
         # query fanza api with keywords
-        caribbeancom_searcher.search(results, part_number, directory)
-        caribbeancom_searcher.search(results, part_number, product_id)
-        fanza_searcher.search(results, part_number, directory)
-        fanza_searcher.search(results, part_number, product_id)
-        knights_visual_searcher.search(results, part_number, directory)
-        knights_visual_searcher.search(results, part_number, product_id)
+        if Prefs["enable_caribbeancom"]:
+            caribbeancom_searcher.search(results, part_number, directory)
+            caribbeancom_searcher.search(results, part_number, product_id)
+        if Prefs["enable_fanza"]:
+            fanza_searcher.search(results, part_number, directory)
+            fanza_searcher.search(results, part_number, product_id)
+        if Prefs["enable_knights_visual"]:
+            knights_visual_searcher.search(results, part_number, directory)
+            knights_visual_searcher.search(results, part_number, product_id)
         Log.Info("Searching is done")
 
     def update(self, metadata, media, lang, force):
@@ -103,6 +106,9 @@ class JavMovieAgent(Agent.Movies):
         Log.Info("Updating force: {}".format(force))
 
         # actual updating
-        caribbeancom_updater.update(metadata)
-        fanza_updater.update(metadata)
-        knights_visual_updater.update(metadata)
+        if Prefs["enable_caribbeancom"]:
+            caribbeancom_updater.update(metadata)
+        if Prefs["enable_fanza"]:
+            fanza_updater.update(metadata)
+        if Prefs["enable_knights_visual"]:
+            knights_visual_updater.update(metadata)

--- a/Contents/DefaultPrefs.json
+++ b/Contents/DefaultPrefs.json
@@ -1,129 +1,20 @@
 [
-  {
-    "id": "debug",
-    "label": "Enable debug logging",
-    "type": "bool",
-    "default": "false"
-  },
-  {
-    "id": "dayfirst",
-    "label": "Enable day first in ambiguous dates",
-    "type": "bool",
-    "default": "false"
-  },
-  {
-    "id": "plot",
-    "label": "Use plot instead of outline\n_____________________________________________________________________________________",
-    "type": "bool",
-    "default": "false"
-  },
-  {
-    "id": "localmediaagent",
-    "label": "Disable local media support for artwork, trailers and subtitles (use local media assets instead)",
-    "type": "bool",
-    "default": "false"
-  },
-  {
-    "id": "trailer",
-    "label": "Enable trailer support",
-    "type": "bool",
-    "default": "false"
-  },
-  {
-    "id": "subtitle",
-    "label": "Enable subtitle file support",
-    "type": "bool",
-    "default": "false"
-  },
-  {
-    "id": "subglobalpath",
-    "label": "Path to global subtitle folder (Leave blank if none)",
-    "type": "text",
-    "default": ""
-  },
-  {
-    "id": "beforerating",
-    "label": "_____________________________________________________________________________________\nText before rating (supports html specialchars!):",
-    "type": "text",
-    "default": "&#9733; "
-  },
-  {
-    "id": "afterrating",
-    "label": "Text after rating (supports html specialchars!):",
-    "type": "text",
-    "default": " | "
-  },
-  {
-    "id": "preserverating",
-    "label": "Pad .nfo rating with texts above and place it in front of summary\n_____________________________________________________________________________________",
-    "type": "bool",
-    "default": "false"
-  },
-  {
-    "id": "tlinsummary",
-    "label": "Show tagline in front of summary\n_____________________________________________________________________________________",
-    "type": "bool",
-    "default": "false"
-  },
-  {
-    "id": "ratings",
-    "label": "Restrict additional ratings to identifiers separated by comma (eg: IMDb, RT). If left empty all ratings found will be included.",
-    "type": "text",
-    "default": ""
-  },
-  {
-    "id": "ratingspos",
-    "label": "position for additional ratings in summary",
-    "type": "enum",
-    "values": [
-      "front",
-      "back"
-    ],
-    "default": "back"
-  },
-  {
-    "id": "altratings",
-    "label": "Enable additional ratings support\n_____________________________________________________________________________________",
-    "type": "bool",
-    "default": "false"
-  },
-  {
-    "id": "collectionsfromtags",
-    "label": "Enable generating Collections from tags\n_____________________________________________________________________________________",
-    "type": "bool",
-    "default": "true"
-  },
-  {
-    "id": "country",
-    "label": "Country (used for content rating)",
-    "type": "enum",
-    "values": [
-      "",
-      "Australia",
-      "Canada",
-      "France",
-      "Germany",
-      "Netherlands",
-      "United Kingdom",
-      "United States"
-    ],
-    "default": ""
-  },
-  {
-    "id": "athumblocation",
-    "label": "actor thumb location",
-    "type": "enum",
-    "values": [
-      "link",
-      "local",
-      "global"
-    ],
-    "default": "link"
-  },
-  {
-    "id": "athumbpath",
-    "label": "path to movie library or global actor folder",
-    "type": "text",
-    "default": "http://localhost"
-  }
+	{
+		"id": "enable_caribbeancom",
+		"label": "Enable Caribbeancom Engine",
+		"type": "bool",
+		"default": "true",
+	},
+	{
+		"id": "enable_fanza",
+		"label": "Enable Fanza Engine",
+		"type": "bool",
+		"default": "true",
+	},
+	{
+		"id": "enable_knights_visual",
+		"label": "Enable Knights-Visual Engine",
+		"type": "bool",
+		"default": "true",
+	}
 ]


### PR DESCRIPTION
Thanks for the awesome plugin.
I have forked it and made a few tweaks and customizations to it.

Here are some of them which I feel would be nice to have in upstream:

* Fix a few places where exceptions aren't caught.
* Scale the Fanza rating from 0-5 on Fanza to 0-10 in Plex.
* Populated directors info from Fanza.
* Added individual switches for each engine (default on).

Also if there's anything else you'd like to absorb upstream, (like the mgstage engine I'm working on), feel free to let me know.